### PR TITLE
Prevent processing the same `inputTransformation` event data many times

### DIFF
--- a/src/pastefromoffice.js
+++ b/src/pastefromoffice.js
@@ -41,8 +41,11 @@ export default class PasteFromOffice extends Plugin {
 		this.listenTo( editor.plugins.get( Clipboard ), 'inputTransformation', ( evt, data ) => {
 			const html = data.dataTransfer.getData( 'text/html' );
 
-			if ( isWordInput( html ) ) {
+			if ( data.pasteFromOfficeProcessed !== true && isWordInput( html ) ) {
 				data.content = this._normalizeWordInput( html, data.dataTransfer );
+
+				// Set the flag so if `inputTransformation` is re-fired, PFO will not process it again (#44).
+				data.pasteFromOfficeProcessed = true;
 			}
 		}, { priority: 'high' } );
 	}

--- a/tests/pastefromoffice.js
+++ b/tests/pastefromoffice.js
@@ -60,4 +60,30 @@ describe( 'Paste from Office plugin', () => {
 
 		expect( normalizeSpy.called ).to.false;
 	} );
+
+	it( 'does not process content many times for the same `inputTransformation` event', () => {
+		const clipboard = editor.plugins.get( 'Clipboard' );
+
+		const dataTransfer = createDataTransfer( {
+			'text/html': '<html><head><meta name="Generator"  content=Microsoft Word 15></head></html>'
+		} );
+
+		let eventRefired = false;
+		clipboard.on( 'inputTransformation', ( evt, data ) => {
+			if ( !eventRefired ) {
+				eventRefired = true;
+
+				evt.stop();
+
+				clipboard.fire( 'inputTransformation', data );
+			}
+
+			expect( data.pasteFromOfficeProcessed ).to.true;
+			expect( normalizeSpy.calledOnce ).to.true;
+		}, { priority: 'low' } );
+
+		editor.plugins.get( 'Clipboard' ).fire( 'inputTransformation', { content, dataTransfer } );
+
+		expect( normalizeSpy.calledOnce ).to.true;
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Prevent processing the same `inputTransformation` event data many times.

---

### Additional information

See #44 (especially https://github.com/ckeditor/ckeditor5-paste-from-office/issues/44#issuecomment-443156415). It is a quickfix so I didn't add any `Closes #44` (but still we may think of moving the vital part of the discussion to another ticket 🤔). There is also one PR in `ckeditor5-image` which needs to be closed with this one - https://github.com/ckeditor/ckeditor5-image/pull/257.
