### PR TITLE
Prevented spaces in spaceruns being removed when it contains a newline

### DIFF
--- a/src/filters/space.js
+++ b/src/filters/space.js
@@ -20,6 +20,7 @@ export function normalizeSpacing( htmlString ) {
 	return normalizeSafariSpaceSpans( normalizeSafariSpaceSpans( htmlString ) ) // Run normalization two times to cover nested spans.
 		.replace( / <\//g, '\u00A0</' )
 		.replace( / <o:p><\/o:p>/g, '\u00A0<o:p></o:p>' )
+		.replace( /(<span style=['"]mso-spacerun:yes['"]>[^\S\r\n]+)[\r\n]+(\s*<\/span>)/g, '$1$2' )
 		.replace( />(\s*(\r\n?|\n)\s*)+</g, '><' );
 }
 

--- a/tests/filters/space.js
+++ b/tests/filters/space.js
@@ -24,6 +24,13 @@ describe( 'Filters', () => {
 				expect( normalizeSpacing( input ) ).to.equal( expected );
 			} );
 
+			it( 'should remove newlines from spacerun spans', () => {
+				const input = '<span style=\'mso-spacerun:yes\'>  \r\n</span>';
+				const expected = '<span style=\'mso-spacerun:yes\'>  </span>';
+
+				expect( normalizeSpacing( input ) ).to.equal( expected );
+			} );
+
 			it( 'should remove multiline sequences of whitespaces', () => {
 				const input = '<p>Foo</p> \n\n   \n<p>Bar</p>   \r\n\r\n  <p>Baz</p>';
 				const expected = '<p>Foo</p><p>Bar</p><p>Baz</p>';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Prevented an error that occurred when a spacerun contains a newline. Closes #49.

---

### Additional information
