### PR TITLE
Handle "spacerun spans" with mixed whitespaces

### DIFF
--- a/src/filters/space.js
+++ b/src/filters/space.js
@@ -17,12 +17,15 @@
  * @returns {String} Input HTML with spaces normalized.
  */
 export function normalizeSpacing( htmlString ) {
-	return normalizeSafariSpaceSpans( normalizeSafariSpaceSpans( htmlString ) ) // Run normalization two times to cover nested spans.
-		.replace( /(<span style=['"]mso-spacerun:yes['"]>[^\S\r\n]*)[\r\n]+(\s*<\/span>)/g, '$1$2' )
+	// Run normalizeSafariSpaceSpans() two times to cover nested spans.
+	return normalizeSafariSpaceSpans( normalizeSafariSpaceSpans( htmlString ) )
+		// Remove all \r\n from "spacerun spans" so the last replace line doesn't strip all whitespaces.
+		.replace( /(<span style=['"]mso-spacerun:yes['"]>[\s]*?)[\r\n]+(\s*<\/span>)/g, '$1$2' )
 		.replace( /<span style=['"]mso-spacerun:yes['"]><\/span>/g, '' )
 		.replace( / <\//g, '\u00A0</' )
 		.replace( / <o:p><\/o:p>/g, '\u00A0<o:p></o:p>' )
-		.replace( />(\s*(\r\n?|\n)\s*)+</g, '><' );
+		// Remove all whitespaces when they contain any \r or \n.
+		.replace( />(\s*[\r\n]\s*)</g, '><' );
 }
 
 /**

--- a/src/filters/space.js
+++ b/src/filters/space.js
@@ -18,9 +18,10 @@
  */
 export function normalizeSpacing( htmlString ) {
 	return normalizeSafariSpaceSpans( normalizeSafariSpaceSpans( htmlString ) ) // Run normalization two times to cover nested spans.
+		.replace( /(<span style=['"]mso-spacerun:yes['"]>[^\S\r\n]*)[\r\n]+(\s*<\/span>)/g, '$1$2' )
+		.replace( /<span style=['"]mso-spacerun:yes['"]><\/span>/g, '' )
 		.replace( / <\//g, '\u00A0</' )
 		.replace( / <o:p><\/o:p>/g, '\u00A0<o:p></o:p>' )
-		.replace( /(<span style=['"]mso-spacerun:yes['"]>[^\S\r\n]+)[\r\n]+(\s*<\/span>)/g, '$1$2' )
 		.replace( />(\s*(\r\n?|\n)\s*)+</g, '><' );
 }
 

--- a/tests/filters/space.js
+++ b/tests/filters/space.js
@@ -24,9 +24,37 @@ describe( 'Filters', () => {
 				expect( normalizeSpacing( input ) ).to.equal( expected );
 			} );
 
-			it( 'should remove newlines from spacerun spans', () => {
-				const input = '<span style=\'mso-spacerun:yes\'>  \r\n</span>';
-				const expected = '<span style=\'mso-spacerun:yes\'>  </span>';
+			it( 'should remove newlines from spacerun spans #1', () => {
+				const input = '<span style=\'mso-spacerun:yes\'>  \n</span>';
+				const expected = '<span style=\'mso-spacerun:yes\'> \u00A0</span>';
+
+				expect( normalizeSpacing( input ) ).to.equal( expected );
+			} );
+
+			it( 'should remove newlines from spacerun spans #2', () => {
+				const input = '<span style=\'mso-spacerun:yes\'> \r\n</span>';
+				const expected = '<span style=\'mso-spacerun:yes\'>\u00A0</span>';
+
+				expect( normalizeSpacing( input ) ).to.equal( expected );
+			} );
+
+			it( 'should remove newlines from spacerun spans #3', () => {
+				const input = '<span style=\'mso-spacerun:yes\'>  \r\n\n  </span>';
+				const expected = '<span style=\'mso-spacerun:yes\'>   \u00A0</span>';
+
+				expect( normalizeSpacing( input ) ).to.equal( expected );
+			} );
+
+			it( 'should remove newlines from spacerun spans #4', () => {
+				const input = '<span style=\'mso-spacerun:yes\'>\n\n\n  </span>';
+				const expected = '<span style=\'mso-spacerun:yes\'> \u00A0</span>';
+
+				expect( normalizeSpacing( input ) ).to.equal( expected );
+			} );
+
+			it( 'should remove newlines from spacerun spans #5', () => {
+				const input = '<span style=\'mso-spacerun:yes\'>\n\n</span>';
+				const expected = '';
 
 				expect( normalizeSpacing( input ) ).to.equal( expected );
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Handle "spacerun spans" with mixed whitespaces. Closes #49. Closes #50.

Huge thanks to [Matt Kobs](https://github.com/kobsy) for this contribution!

---

### Additional information

See #49 and #50 (base PR). Apart from the fix in base PR added by @kobsy which covers _preventing spaces in `spacerun spans` being removed when mixed with newline_ I have modified the regexp to handle more cases of mixed whitespace and also added handling for empty `spacerun spans` (because you never know what Word may produce) and a few unit tests.
