### PR TITLE
Fix typo in links to modules

### DIFF
--- a/src/pastefromoffice.js
+++ b/src/pastefromoffice.js
@@ -21,8 +21,8 @@ import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
  *
  * Transformation is made by a set of predefined {@link module:paste-from-office/normalizer~Normalizer normalizers}.
  * This plugin includes following normalizers:
- *   * {@link module:paste-from-office/normalizer/mswordnormalizer~MSWordNormalizer Microsoft Word normalizer}
- *   * {@link module:paste-from-office/normalizer/googledocsnormalizer~GoogleDocsNormalizer Google Docs normalizer}
+ *   * {@link module:paste-from-office/normalizers/mswordnormalizer~MSWordNormalizer Microsoft Word normalizer}
+ *   * {@link module:paste-from-office/normalizers/googledocsnormalizer~GoogleDocsNormalizer Google Docs normalizer}
  *
  * For more information about this feature check the {@glink api/paste-from-office package page}.
  *


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Fix typo in links to modules.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
