### PR TITLE
Fixed various issues with oddly formatted space run spans

### DIFF
--- a/src/filters/space.js
+++ b/src/filters/space.js
@@ -20,8 +20,8 @@ export function normalizeSpacing( htmlString ) {
 	// Run normalizeSafariSpaceSpans() two times to cover nested spans.
 	return normalizeSafariSpaceSpans( normalizeSafariSpaceSpans( htmlString ) )
 		// Remove all \r\n from "spacerun spans" so the last replace line doesn't strip all whitespaces.
-		.replace( /(<span style=['"]mso-spacerun:yes['"]>[\s]*?)[\r\n]+(\s*<\/span>)/g, '$1$2' )
-		.replace( /<span style=['"]mso-spacerun:yes['"]><\/span>/g, '' )
+		.replace( /(<span\s+style=['"]mso-spacerun:yes['"]>[\s]*?)[\r\n]+(\s*<\/span>)/g, '$1$2' )
+		.replace( /<span\s+style=['"]mso-spacerun:yes['"]><\/span>/g, '' )
 		.replace( / <\//g, '\u00A0</' )
 		.replace( / <o:p><\/o:p>/g, '\u00A0<o:p></o:p>' )
 		// Remove <o:p> block filler from empty paragraph. Safari uses \u00A0 instead of &nbsp;.

--- a/tests/filters/space.js
+++ b/tests/filters/space.js
@@ -81,6 +81,24 @@ describe( 'PasteFromOffice - filters', () => {
 
 				expect( normalizeSpacing( input ) ).to.equal( expected );
 			} );
+
+			// ckeditor5#2095
+			it( 'should detect space spans which are split into multiple lines', () => {
+				const input =
+					'<p><span style=\'font-size:13.0pt;line-height:150%;\n' +
+					'font-family:"Times New Roman",serif\'><span\n' +
+					'style=\'mso-spacerun:yes\'>\n' +
+					'</span><span style=\'mso-spacerun:yes\'>          </span><span\n' +
+					'style=\'mso-spacerun:yes\'>    </span><span style=\'mso-spacerun:yes\'> </span>Test<o:p></o:p></span></p>';
+
+				const expected =
+					'<p><span style=\'font-size:13.0pt;line-height:150%;\nfont-family:"Times New Roman",serif\'>' +
+					'<span style=\'mso-spacerun:yes\'>          </span>' +
+					'<span\nstyle=\'mso-spacerun:yes\'>    </span>' +
+					'<span style=\'mso-spacerun:yes\'> </span>Test<o:p></o:p></span></p>';
+
+				expect( normalizeSpacing( input ) ).to.equal( expected );
+			} );
 		} );
 
 		describe( 'normalizeSpacerunSpans()', () => {
@@ -101,6 +119,7 @@ describe( 'PasteFromOffice - filters', () => {
 				expect( htmlDocument.body.innerHTML.replace( /'/g, '"' ).replace( /: /g, ':' ) ).to.equal( expected );
 			} );
 
+			// ckeditor5#5645
 			it( 'should normalize spaces inside special "span.spacerun" elements that contain no data', () => {
 				const input = '<p> <span style=\'mso-spacerun:yes\'>   </span>Foo</p>' +
 					'<p> Baz <span style=\'mso-spacerun:yes\'></span></p>';

--- a/tests/filters/space.js
+++ b/tests/filters/space.js
@@ -100,6 +100,7 @@ describe( 'PasteFromOffice - filters', () => {
 
 				expect( htmlDocument.body.innerHTML.replace( /'/g, '"' ).replace( /: /g, ':' ) ).to.equal( expected );
 			} );
+
 			it( 'should normalize spaces inside special "span.spacerun" elements that contain no data', () => {
 				const input = '<p> <span style=\'mso-spacerun:yes\'>   </span>Foo</p>' +
 					'<p> Baz <span style=\'mso-spacerun:yes\'></span></p>';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed issues with oddly formatted space run spans. Closes ckeditor/ckeditor5#5645. Closes ckeditor/ckeditor5#2095.

---

### Additional information

* Based on contrib https://github.com/ckeditor/ckeditor5-paste-from-office/pull/88
* Thanks @amrita-syn and @dkrahn for input
* I didn't actually test it with Word. From code's perspective reported problems seem obvious, but some final check with Word would be good.
