### PR TITLE
i/6324: Register global variable `window.preventPasteFromOfficeNotification`

### DIFF
--- a/docs/_snippets/features/paste-from-office.js
+++ b/docs/_snippets/features/paste-from-office.js
@@ -69,6 +69,8 @@ ClassicEditor
 	} )
 	.then( editor => {
 		window.editor = editor;
+		// Prevent showing a warning notification when user is pasting a content from MS Word or Google Docs.
+		window.preventPasteFromOfficeNotification = true;
 	} )
 	.catch( err => {
 		console.error( err.stack );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Registered a global variable `window.preventPasteFromOfficeNotification` preventing showing a warning notification when user tries to paste content from MS Word or Google Docs. See ckeditor/ckeditor5#6324.

--

Main PR: https://github.com/ckeditor/ckeditor5/pull/6384