### PR TITLE
Numerical values for the FontSize plugin

### DIFF
--- a/docs/_snippets/features/paste-from-office.js
+++ b/docs/_snippets/features/paste-from-office.js
@@ -68,6 +68,7 @@ ClassicEditor
 			supportAllValues: true
 		},
 		fontSize: {
+			options: [ 10, 12, 14, 'default', 18, 20, 22 ],
 			supportAllValues: true
 		},
 		placeholder: 'Paste the content here to test the feature.',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Use numerical values as options in font size dropdown when `fontSize.supportAllValues=true`. See ckeditor/ckeditor5-font#62
